### PR TITLE
feat: replace mock campaign data with API calls

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -3,7 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_CLAUDE_API_KEY?: string;
   // Add other env variables here as needed:
-  // readonly VITE_API_BASE_URL?: string;
+  readonly VITE_API_BASE_URL?: string;
 }
 
 interface ImportMeta {

--- a/src/panels/CampaignsPanel.tsx
+++ b/src/panels/CampaignsPanel.tsx
@@ -20,6 +20,7 @@ const CampaignsPanel: React.FC = () => {
   const [modalMode, setModalMode] = useState<"create" | "edit">("create");
   const [stats, setStats] = useState<CampaignStats | null>(null);
   const [loadingStats, setLoadingStats] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     void loadStats();
@@ -28,10 +29,13 @@ const CampaignsPanel: React.FC = () => {
   const loadStats = async () => {
     try {
       setLoadingStats(true);
+      setError(null);
       const data = await campaignService.getCampaignStats();
       setStats(data);
-    } catch (error) {
-      console.error("Failed to load campaign stats:", error);
+    } catch (err: any) {
+      console.error("Failed to load campaign stats:", err);
+      setStats(null);
+      setError(err.message || "Failed to load campaign stats");
     } finally {
       setLoadingStats(false);
     }
@@ -76,14 +80,23 @@ const CampaignsPanel: React.FC = () => {
         );
         if (updated) setSelectedCampaign(updated);
       }
-    } catch (error) {
-      console.error("Failed to save campaign:", error);
+      setError(null);
+    } catch (err: any) {
+      console.error("Failed to save campaign:", err);
+      setError(err.message || "Failed to save campaign");
     }
   };
+
+  const errorMessage = error && (
+    <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+      <p className="text-red-800">{error}</p>
+    </div>
+  );
 
   if (viewMode === "detail" && selectedCampaign) {
     return (
       <div className="space-y-6">
+        {errorMessage}
         <div className="flex items-center gap-4">
           <button
             onClick={handleBackToList}
@@ -123,6 +136,7 @@ const CampaignsPanel: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      {errorMessage}
       <div>
         <h2 className="text-2xl font-semibold text-gray-900 mb-4">
           Campaign Overview

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,18 +1,36 @@
 const API_BASE =
   import.meta.env.VITE_API_BASE_URL || "http://localhost:4000/api";
 
-interface ApiResponse<T> {
-  data: T;
-  error?: string;
+async function request<T>(
+  endpoint: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${endpoint}`, {
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || res.statusText);
+  }
+  if (res.status === 204) {
+    // No content
+    return undefined as T;
+  }
+  return (await res.json()) as T;
 }
 
-export async function apiGet<T>(endpoint: string): Promise<ApiResponse<T>> {
-  try {
-    const res = await fetch(`${API_BASE}/${endpoint}`);
-    if (!res.ok) throw new Error(`API error: ${res.statusText}`);
-    const data = (await res.json()) as T;
-    return { data };
-  } catch (error: any) {
-    return { data: null as any, error: error.message };
-  }
-}
+export const apiClient = {
+  get: <T>(endpoint: string) => request<T>(endpoint),
+  post: <T>(endpoint: string, body: unknown) =>
+    request<T>(endpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  put: <T>(endpoint: string, body: unknown) =>
+    request<T>(endpoint, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+  delete: <T>(endpoint: string) => request<T>(endpoint, { method: "DELETE" }),
+};

--- a/src/services/campaignService.ts
+++ b/src/services/campaignService.ts
@@ -1,4 +1,5 @@
 // src/services/campaignService.ts
+import { apiClient } from "./apiClient";
 import { Campaign } from "../models/campaign";
 
 // Define CampaignStats interface here since it's not exported from models
@@ -9,180 +10,37 @@ export interface CampaignStats {
   successRate: string;
 }
 
-// Mock data for development - using 'any' to avoid type conflicts
-const mockCampaigns: any[] = [
-  {
-    id: "1",
-    name: "Annual Fundraiser 2024",
-    description: "Our biggest fundraising event of the year",
-    goal: 100000,
-    raised: 75000,
-    startDate: "2024-01-01",
-    endDate: "2024-12-31",
-    status: "Active",
-    category: "General",
-  },
-  {
-    id: "2",
-    name: "Emergency Relief Fund",
-    description: "Supporting families in crisis",
-    goal: 50000,
-    raised: 32000,
-    startDate: "2024-06-01",
-    endDate: "2024-08-31",
-    status: "Active",
-    category: "Emergency",
-  },
-];
+const BASE_PATH = "/campaigns";
 
-export async function getAllCampaigns(_filters?: any): Promise<Campaign[]> {
-  try {
-    // Simulate API call delay
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    // In a real app, this would be:
-    // const response = await fetch('/api/campaigns', {
-    //   method: 'GET',
-    //   headers: { 'Content-Type': 'application/json' }
-    // });
-    // return await response.json();
-
-    // For now, return mock data
-    return mockCampaigns;
-  } catch (error) {
-    console.error("Error fetching campaigns:", error);
-    throw new Error("Failed to fetch campaigns");
-  }
+export async function getAllCampaigns(
+  filters: Record<string, unknown> = {},
+): Promise<Campaign[]> {
+  const params = new URLSearchParams(filters as Record<string, string>);
+  const endpoint = `${BASE_PATH}${params.toString() ? `?${params.toString()}` : ""}`;
+  return apiClient.get<Campaign[]>(endpoint);
 }
 
-export async function getCampaignById(id: string): Promise<Campaign | null> {
-  try {
-    await new Promise((resolve) => setTimeout(resolve, 300));
-
-    // In a real app:
-    // const response = await fetch(`/api/campaigns/${id}`);
-    // if (!response.ok) return null;
-    // return await response.json();
-
-    return mockCampaigns.find((campaign) => campaign.id === id) || null;
-  } catch (error) {
-    console.error("Error fetching campaign:", error);
-    return null;
-  }
+export function getCampaignById(id: string): Promise<Campaign> {
+  return apiClient.get<Campaign>(`${BASE_PATH}/${id}`);
 }
 
-export async function createCampaign(
+export function createCampaign(
   campaignData: Partial<Campaign>,
 ): Promise<Campaign> {
-  try {
-    await new Promise((resolve) => setTimeout(resolve, 800));
-
-    // In a real app:
-    // const response = await fetch('/api/campaigns', {
-    //   method: 'POST',
-    //   headers: { 'Content-Type': 'application/json' },
-    //   body: JSON.stringify(campaignData)
-    // });
-    // return await response.json();
-
-    const newCampaign: any = {
-      id: Date.now().toString(),
-      name: campaignData.name || "New Campaign",
-      description: campaignData.description || "",
-      goal: campaignData.goal || 0,
-      raised: 0,
-      startDate:
-        campaignData.startDate || new Date().toISOString().split("T")[0],
-      endDate: campaignData.endDate || new Date().toISOString().split("T")[0],
-      status: "Active",
-      category: campaignData.category || "General",
-    };
-
-    mockCampaigns.push(newCampaign);
-    return newCampaign as Campaign;
-  } catch (error) {
-    console.error("Error creating campaign:", error);
-    throw new Error("Failed to create campaign");
-  }
+  return apiClient.post<Campaign>(BASE_PATH, campaignData);
 }
 
-export async function updateCampaign(
+export function updateCampaign(
   id: string,
   updates: Partial<Campaign>,
 ): Promise<Campaign> {
-  try {
-    await new Promise((resolve) => setTimeout(resolve, 600));
-
-    // In a real app:
-    // const response = await fetch(`/api/campaigns/${id}`, {
-    //   method: 'PUT',
-    //   headers: { 'Content-Type': 'application/json' },
-    //   body: JSON.stringify(updates)
-    // });
-    // return await response.json();
-
-    const campaignIndex = mockCampaigns.findIndex((c) => c.id === id);
-    if (campaignIndex === -1) {
-      throw new Error("Campaign not found");
-    }
-
-    mockCampaigns[campaignIndex] = {
-      ...mockCampaigns[campaignIndex],
-      ...updates,
-    };
-    return mockCampaigns[campaignIndex];
-  } catch (error) {
-    console.error("Error updating campaign:", error);
-    throw new Error("Failed to update campaign");
-  }
+  return apiClient.put<Campaign>(`${BASE_PATH}/${id}`, updates);
 }
 
-export async function deleteCampaign(id: string): Promise<void> {
-  try {
-    await new Promise((resolve) => setTimeout(resolve, 400));
-
-    // In a real app:
-    // await fetch(`/api/campaigns/${id}`, { method: 'DELETE' });
-
-    const campaignIndex = mockCampaigns.findIndex((c) => c.id === id);
-    if (campaignIndex !== -1) {
-      mockCampaigns.splice(campaignIndex, 1);
-    }
-  } catch (error) {
-    console.error("Error deleting campaign:", error);
-    throw new Error("Failed to delete campaign");
-  }
+export function deleteCampaign(id: string): Promise<void> {
+  return apiClient.delete<void>(`${BASE_PATH}/${id}`);
 }
 
-export async function getCampaignStats(): Promise<CampaignStats> {
-  try {
-    await new Promise((resolve) => setTimeout(resolve, 400));
-
-    // In a real app:
-    // const response = await fetch('/api/campaigns/stats');
-    // return await response.json();
-
-    const totalCampaigns = mockCampaigns.length;
-    const activeCampaigns = mockCampaigns.filter(
-      (c) => c.status === "Active",
-    ).length;
-    const totalRaised = mockCampaigns.reduce((sum, c) => sum + c.raised, 0);
-    const successfulCampaigns = mockCampaigns.filter(
-      (c) => c.raised >= c.goal,
-    ).length;
-    const successRate =
-      totalCampaigns > 0
-        ? ((successfulCampaigns / totalCampaigns) * 100).toFixed(1)
-        : "0";
-
-    return {
-      totalCampaigns,
-      activeCampaigns,
-      totalRaised: `$${totalRaised.toLocaleString()}`,
-      successRate: `${successRate}%`,
-    };
-  } catch (error) {
-    console.error("Error fetching campaign stats:", error);
-    throw new Error("Failed to fetch campaign stats");
-  }
+export function getCampaignStats(): Promise<CampaignStats> {
+  return apiClient.get<CampaignStats>(`${BASE_PATH}/stats`);
 }


### PR DESCRIPTION
## Summary
- replace campaign mock data with API requests
- externalize API base URL and centralize HTTP error handling
- surface campaign API errors in CampaignsPanel

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898f40e695c83218d960b39ddacab2e