### PR TITLE
refactor: modularize Claude panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "fix:unused": "pnpm lint:json && node scripts/fix-unused-from-eslint.mjs .eslint-unused.json && rm -f .eslint-unused.json",
     "fix:unused:node": "node scripts/fix-unused-from-eslint.mjs .eslint-unused.json",
     "verify:barrels": "node scripts/verify-barrels.mjs",
-    "check:paths": "pnpm lint && pnpm verify:barrels"
+    "check:paths": "pnpm lint && pnpm verify:barrels",
+    "test": "vitest"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -42,6 +43,8 @@
     "@eslint/js": "^9.33.0",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^16.0.0",
     "@types/crypto-js": "^4.2.2",
     "@types/node": "^20.19.10",
     "@types/react": "^19.1.9",
@@ -62,7 +65,9 @@
     "tailwindcss": "^4.1.11",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0",
-    "vite": "^7.1.1"
+    "vite": "^7.1.1",
+    "vitest": "^2.1.1",
+    "jsdom": "^24.0.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/components/IconBadge.tsx
+++ b/src/components/IconBadge.tsx
@@ -1,0 +1,22 @@
+import clsx from "clsx";
+import type { ComponentType } from "react";
+
+export interface IconBadgeProps {
+  icon: ComponentType<{ className?: string }>;
+  className?: string;
+  iconClassName?: string;
+}
+
+const IconBadge: React.FC<IconBadgeProps> = ({
+  icon: Icon,
+  className,
+  iconClassName,
+}) => {
+  return (
+    <div className={clsx("p-2 bg-slate-800/50 rounded-lg", className)}>
+      <Icon className={clsx("w-5 h-5 text-slate-400", iconClassName)} />
+    </div>
+  );
+};
+
+export default IconBadge;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,43 @@
+import clsx from "clsx";
+import { LucideIcon } from "lucide-react";
+import { ButtonHTMLAttributes } from "react";
+
+export interface IconButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  icon: LucideIcon;
+  variant?: "default" | "success";
+}
+
+const variantClasses: Record<
+  NonNullable<IconButtonProps["variant"]>,
+  string
+> = {
+  default:
+    "bg-slate-800/50 text-slate-300 hover:text-white hover:bg-slate-700/50 border-slate-700/50",
+  success: "bg-green-600/20 text-green-400 border-green-500/30",
+};
+
+const IconButton: React.FC<IconButtonProps> = ({
+  label,
+  icon: Icon,
+  variant = "default",
+  className,
+  ...props
+}) => {
+  return (
+    <button
+      className={clsx(
+        "px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center space-x-2 border",
+        variantClasses[variant],
+        className,
+      )}
+      {...props}
+    >
+      <Icon className="w-4 h-4" />
+      <span>{label}</span>
+    </button>
+  );
+};
+
+export default IconButton;

--- a/src/components/__tests__/IconBadge.test.tsx
+++ b/src/components/__tests__/IconBadge.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import { Send } from "lucide-react";
+import { describe, it, expect } from "vitest";
+
+import IconBadge from "../IconBadge";
+
+import "@testing-library/jest-dom";
+
+describe("IconBadge", () => {
+  it("renders provided icon", () => {
+    const { container } = render(<IconBadge icon={Send} />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/IconButton.test.tsx
+++ b/src/components/__tests__/IconButton.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Send } from "lucide-react";
+import { describe, it, expect, vi } from "vitest";
+
+import IconButton from "../IconButton";
+
+import "@testing-library/jest-dom";
+
+describe("IconButton", () => {
+  it("renders label and handles click", () => {
+    const handleClick = vi.fn();
+    render(<IconButton label="Send" icon={Send} onClick={handleClick} />);
+
+    const button = screen.getByRole("button", { name: /send/i });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,8 @@ export { default as CampaignList } from "./CampaignList";
 export { default as CampaignModal } from "./CampaignModal";
 export { default as PerformanceChart } from "./PerformanceChart";
 export { default as DonorInsightsPanel } from "./DonorInsightsPanel";
+export { default as IconButton } from "./IconButton";
+export { default as IconBadge } from "./IconBadge";
 
 // Export ui-kit components individually instead of wildcard
 export { Card, Input, Panel } from "./ui-kit";

--- a/src/features/claude/ClaudeActionList.test.tsx
+++ b/src/features/claude/ClaudeActionList.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MessageSquare } from "lucide-react";
+import { describe, it, expect, vi } from "vitest";
+
+import ClaudeActionList, { ClaudeAction } from "./ClaudeActionList";
+
+import "@testing-library/jest-dom";
+
+describe("ClaudeActionList", () => {
+  const actions: ClaudeAction[] = [
+    {
+      id: "test",
+      label: "Test Action",
+      description: "desc",
+      icon: MessageSquare,
+      prompt: "",
+    },
+  ];
+
+  it("calls onSelect when action clicked", () => {
+    const handleSelect = vi.fn();
+    render(
+      <ClaudeActionList
+        actions={actions}
+        onSelect={handleSelect}
+        isLoading={false}
+      />,
+    );
+    fireEvent.click(screen.getByText(/test action/i));
+    expect(handleSelect).toHaveBeenCalledWith("test");
+  });
+});

--- a/src/features/claude/ClaudeActionList.tsx
+++ b/src/features/claude/ClaudeActionList.tsx
@@ -1,0 +1,65 @@
+import { Zap, Sparkles } from "lucide-react";
+import type { ComponentType } from "react";
+
+import IconBadge from "@/components/IconBadge";
+
+export interface ClaudeAction {
+  id: string;
+  label: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  prompt: string;
+}
+
+export interface ClaudeActionListProps {
+  actions: ClaudeAction[];
+  onSelect: (id: string) => void;
+  isLoading: boolean;
+}
+
+const ClaudeActionList: React.FC<ClaudeActionListProps> = ({
+  actions,
+  onSelect,
+  isLoading,
+}) => {
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-white mb-4 flex items-center">
+        <Sparkles className="w-5 h-5 mr-2 text-purple-400" />
+        Quick Actions
+      </h3>
+      <div className="grid grid-cols-1 gap-3">
+        {actions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <button
+              key={action.id}
+              onClick={() => onSelect(action.id)}
+              disabled={isLoading}
+              className="p-4 text-left border border-slate-700/50 rounded-xl hover:border-purple-500/50 hover:bg-slate-800/50 transition-all duration-200 group disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <div className="flex items-start space-x-3">
+                <IconBadge
+                  icon={Icon}
+                  className="group-hover:bg-purple-600/20 transition-colors"
+                  iconClassName="group-hover:text-purple-400"
+                />
+                <div className="flex-1">
+                  <div className="font-medium text-white group-hover:text-purple-300 transition-colors">
+                    {action.label}
+                  </div>
+                  <div className="text-sm text-slate-400 mt-1">
+                    {action.description}
+                  </div>
+                </div>
+                <Zap className="w-4 h-4 text-slate-500 group-hover:text-purple-400 transition-colors" />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ClaudeActionList;

--- a/src/features/claude/ClaudePanel.tsx
+++ b/src/features/claude/ClaudePanel.tsx
@@ -1,33 +1,24 @@
-/* eslint-disable */
-import { useState, useCallback, useEffect } from "react";
 import {
   X,
-  Send,
   Bot,
-  Copy,
-  RotateCcw,
-  Sparkles,
   MessageSquare,
+  Sparkles,
   Target,
   TrendingUp,
-  // Users,
-  Zap,
-  CheckCircle,
 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import IconBadge from "@/components/IconBadge";
+
+import ClaudeActionList, { ClaudeAction } from "./ClaudeActionList";
+import ClaudePromptForm from "./ClaudePromptForm";
+import ClaudeResponseView from "./ClaudeResponseView";
 
 interface ClaudePanelProps {
   isOpen: boolean;
   onClose: () => void;
   currentCampaign?: any;
   onCampaignSelect?: (campaign: any) => void;
-}
-
-interface ClaudeAction {
-  id: string;
-  label: string;
-  description: string;
-  icon: React.ComponentType<{ className?: string }>;
-  prompt: string;
 }
 
 const ClaudePanel: React.FC<ClaudePanelProps> = ({
@@ -82,7 +73,6 @@ const ClaudePanel: React.FC<ClaudePanelProps> = ({
       setSelectedAction(actionType);
 
       try {
-        // Simulate AI response
         await new Promise((resolve) => setTimeout(resolve, 2000));
 
         const mockResponses = {
@@ -161,10 +151,10 @@ Expected outcome: 25-30% increase in final weeks with focused effort.`,
         };
 
         setResponse(
-          mockResponses[actionType as keyof typeof mockResponses] ||
+          (mockResponses as Record<string, string>)[actionType] ||
             "Response generated successfully!",
         );
-      } catch (error) {
+      } catch {
         setResponse("Sorry, I encountered an error. Please try again.");
       } finally {
         setIsLoading(false);
@@ -188,7 +178,7 @@ I'd be happy to help with that! For your ${currentCampaign?.name || "campaign"},
 This is a custom response based on your specific request. The AI assistant would provide tailored advice, content, or analysis based on your exact needs and current campaign data.
 
 Would you like me to elaborate on any specific aspect or generate additional content?`);
-    } catch (error) {
+    } catch {
       setResponse("Sorry, I encountered an error. Please try again.");
     } finally {
       setIsLoading(false);
@@ -213,7 +203,6 @@ Would you like me to elaborate on any specific aspect or generate additional con
     setCustomPrompt("");
   }, []);
 
-  // Handle escape key
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === "Escape" && isOpen) {
@@ -231,21 +220,20 @@ Would you like me to elaborate on any specific aspect or generate additional con
 
   return (
     <>
-      {/* Backdrop */}
       <div
         className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 transition-opacity duration-300"
         onClick={onClose}
       />
 
-      {/* Panel */}
       <div className="fixed right-0 top-0 h-full w-full max-w-2xl bg-slate-900/95 backdrop-blur-xl border-l border-slate-700/50 shadow-2xl z-50 overflow-hidden">
         <div className="flex flex-col h-full">
-          {/* Header */}
           <div className="flex items-center justify-between p-6 border-b border-slate-700/50 bg-slate-800/50">
             <div className="flex items-center space-x-3">
-              <div className="p-2 bg-purple-600/20 rounded-xl">
-                <Bot className="w-6 h-6 text-purple-400" />
-              </div>
+              <IconBadge
+                icon={Bot}
+                className="bg-purple-600/20 rounded-xl"
+                iconClassName="w-6 h-6 text-purple-400"
+              />
               <div>
                 <h2 className="text-xl font-semibold text-white">
                   AI Assistant
@@ -263,7 +251,6 @@ Would you like me to elaborate on any specific aspect or generate additional con
             </button>
           </div>
 
-          {/* Campaign Info */}
           {currentCampaign && (
             <div className="p-6 bg-slate-800/30 border-b border-slate-700/30">
               <div className="flex items-center justify-between">
@@ -304,76 +291,23 @@ Would you like me to elaborate on any specific aspect or generate additional con
             </div>
           )}
 
-          {/* Content */}
           <div className="flex-1 overflow-y-auto">
             {!response && !isLoading && (
               <div className="p-6 space-y-6">
-                <div>
-                  <h3 className="text-lg font-semibold text-white mb-4 flex items-center">
-                    <Sparkles className="w-5 h-5 mr-2 text-purple-400" />
-                    Quick Actions
-                  </h3>
-                  {currentCampaign && (
-                    <div className="grid grid-cols-1 gap-3">
-                      {claudeActions.map((action) => {
-                        const Icon = action.icon;
-                        return (
-                          <button
-                            key={action.id}
-                            onClick={() => handleGenerate(action.id)}
-                            disabled={isLoading}
-                            className="p-4 text-left border border-slate-700/50 rounded-xl hover:border-purple-500/50 hover:bg-slate-800/50 transition-all duration-200 group disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <div className="flex items-start space-x-3">
-                              <div className="p-2 bg-slate-800/50 rounded-lg group-hover:bg-purple-600/20 transition-colors">
-                                <Icon className="w-5 h-5 text-slate-400 group-hover:text-purple-400" />
-                              </div>
-                              <div className="flex-1">
-                                <div className="font-medium text-white group-hover:text-purple-300 transition-colors">
-                                  {action.label}
-                                </div>
-                                <div className="text-sm text-slate-400 mt-1">
-                                  {action.description}
-                                </div>
-                              </div>
-                              <Zap className="w-4 h-4 text-slate-500 group-hover:text-purple-400 transition-colors" />
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                {/* Custom Prompt */}
-                <div className="space-y-4">
-                  <h3 className="text-lg font-semibold text-white flex items-center">
-                    <MessageSquare className="w-5 h-5 mr-2 text-blue-400" />
-                    Custom Request
-                  </h3>
-                  <div className="space-y-3">
-                    <textarea
-                      value={customPrompt}
-                      onChange={(e) => setCustomPrompt(e.target.value)}
-                      placeholder="Ask Claude anything about your campaign, request content creation, or get strategic advice..."
-                      className="w-full h-24 bg-slate-800/50 border border-slate-700/50 rounded-xl px-4 py-3 text-white placeholder-slate-400 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 focus:outline-none resize-none transition-all"
-                    />
-                    <button
-                      onClick={handleCustomGenerate}
-                      disabled={isLoading || !customPrompt.trim()}
-                      className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-slate-700 disabled:cursor-not-allowed text-white font-medium py-3 px-4 rounded-xl transition-all duration-200 flex items-center justify-center space-x-2"
-                    >
-                      <Send className="w-4 h-4" />
-                      <span>
-                        {isLoading ? "Generating..." : "Send to Claude"}
-                      </span>
-                    </button>
-                  </div>
-                </div>
+                <ClaudeActionList
+                  actions={claudeActions}
+                  onSelect={handleGenerate}
+                  isLoading={isLoading}
+                />
+                <ClaudePromptForm
+                  value={customPrompt}
+                  onChange={setCustomPrompt}
+                  onSubmit={handleCustomGenerate}
+                  isLoading={isLoading}
+                />
               </div>
             )}
 
-            {/* Loading State */}
             {isLoading && (
               <div className="p-6 flex flex-col items-center justify-center space-y-4">
                 <div className="relative">
@@ -386,48 +320,21 @@ Would you like me to elaborate on any specific aspect or generate additional con
                   </p>
                   <p className="text-slate-400 text-sm mt-1">
                     {selectedAction &&
-                      `Generating ${claudeActions.find((a) => a.id === selectedAction)?.label.toLowerCase()}`}
+                      `Generating ${claudeActions
+                        .find((a) => a.id === selectedAction)
+                        ?.label.toLowerCase()}`}
                   </p>
                 </div>
               </div>
             )}
 
-            {/* Response */}
             {response && (
-              <div className="p-6 space-y-4">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-lg font-semibold text-white flex items-center">
-                    <CheckCircle className="w-5 h-5 mr-2 text-green-400" />
-                    Claude's Response
-                  </h3>
-                  <div className="flex space-x-2">
-                    <button
-                      onClick={handleCopy}
-                      className={`px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center space-x-2 ${
-                        copySuccess
-                          ? "bg-green-600/20 text-green-400 border border-green-500/30"
-                          : "bg-slate-800/50 text-slate-300 hover:text-white hover:bg-slate-700/50 border border-slate-700/50"
-                      }`}
-                    >
-                      <Copy className="w-4 h-4" />
-                      <span>{copySuccess ? "Copied!" : "Copy"}</span>
-                    </button>
-                    <button
-                      onClick={handleNewRequest}
-                      className="px-3 py-2 bg-slate-800/50 text-slate-300 hover:text-white hover:bg-slate-700/50 rounded-lg text-sm font-medium transition-all duration-200 flex items-center space-x-2 border border-slate-700/50"
-                    >
-                      <RotateCcw className="w-4 h-4" />
-                      <span>New Request</span>
-                    </button>
-                  </div>
-                </div>
-
-                <div className="bg-slate-800/30 border border-slate-700/30 rounded-xl p-4">
-                  <pre className="whitespace-pre-wrap text-slate-200 text-sm leading-relaxed font-mono">
-                    {response}
-                  </pre>
-                </div>
-              </div>
+              <ClaudeResponseView
+                response={response}
+                copySuccess={copySuccess}
+                onCopy={handleCopy}
+                onNewRequest={handleNewRequest}
+              />
             )}
           </div>
         </div>

--- a/src/features/claude/ClaudePromptForm.test.tsx
+++ b/src/features/claude/ClaudePromptForm.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import ClaudePromptForm from "./ClaudePromptForm";
+
+import "@testing-library/jest-dom";
+
+describe("ClaudePromptForm", () => {
+  it("submits custom prompt", () => {
+    const handleSubmit = vi.fn();
+    const handleChange = vi.fn();
+    render(
+      <ClaudePromptForm
+        value=""
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+        isLoading={false}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText(/ask claude/i);
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    expect(handleChange).toHaveBeenCalledWith("hello");
+    const button = screen.getByRole("button", { name: /send to claude/i });
+    fireEvent.click(button);
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/features/claude/ClaudePromptForm.tsx
+++ b/src/features/claude/ClaudePromptForm.tsx
@@ -1,0 +1,47 @@
+import { MessageSquare, Send } from "lucide-react";
+import { ChangeEvent } from "react";
+
+export interface ClaudePromptFormProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  isLoading: boolean;
+}
+
+const ClaudePromptForm: React.FC<ClaudePromptFormProps> = ({
+  value,
+  onChange,
+  onSubmit,
+  isLoading,
+}) => {
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(e.target.value);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-white flex items-center">
+        <MessageSquare className="w-5 h-5 mr-2 text-blue-400" />
+        Custom Request
+      </h3>
+      <div className="space-y-3">
+        <textarea
+          value={value}
+          onChange={handleChange}
+          placeholder="Ask Claude anything about your campaign, request content creation, or get strategic advice..."
+          className="w-full h-24 bg-slate-800/50 border border-slate-700/50 rounded-xl px-4 py-3 text-white placeholder-slate-400 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 focus:outline-none resize-none transition-all"
+        />
+        <button
+          onClick={onSubmit}
+          disabled={isLoading || !value.trim()}
+          className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-slate-700 disabled:cursor-not-allowed text-white font-medium py-3 px-4 rounded-xl transition-all duration-200 flex items-center justify-center space-x-2"
+        >
+          <Send className="w-4 h-4" />
+          <span>{isLoading ? "Generating..." : "Send to Claude"}</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ClaudePromptForm;

--- a/src/features/claude/ClaudeResponseView.test.tsx
+++ b/src/features/claude/ClaudeResponseView.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import ClaudeResponseView from "./ClaudeResponseView";
+
+import "@testing-library/jest-dom";
+
+describe("ClaudeResponseView", () => {
+  it("handles copy and new request actions", () => {
+    const handleCopy = vi.fn();
+    const handleNew = vi.fn();
+    render(
+      <ClaudeResponseView
+        response="test"
+        copySuccess={false}
+        onCopy={handleCopy}
+        onNewRequest={handleNew}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    fireEvent.click(screen.getByRole("button", { name: /new request/i }));
+    expect(handleCopy).toHaveBeenCalled();
+    expect(handleNew).toHaveBeenCalled();
+  });
+});

--- a/src/features/claude/ClaudeResponseView.tsx
+++ b/src/features/claude/ClaudeResponseView.tsx
@@ -1,0 +1,49 @@
+import { CheckCircle, Copy, RotateCcw } from "lucide-react";
+
+import IconButton from "@/components/IconButton";
+
+export interface ClaudeResponseViewProps {
+  response: string;
+  copySuccess: boolean;
+  onCopy: () => void;
+  onNewRequest: () => void;
+}
+
+const ClaudeResponseView: React.FC<ClaudeResponseViewProps> = ({
+  response,
+  copySuccess,
+  onCopy,
+  onNewRequest,
+}) => {
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white flex items-center">
+          <CheckCircle className="w-5 h-5 mr-2 text-green-400" />
+          Claude's Response
+        </h3>
+        <div className="flex space-x-2">
+          <IconButton
+            onClick={onCopy}
+            label={copySuccess ? "Copied!" : "Copy"}
+            icon={Copy}
+            variant={copySuccess ? "success" : "default"}
+          />
+          <IconButton
+            onClick={onNewRequest}
+            label="New Request"
+            icon={RotateCcw}
+          />
+        </div>
+      </div>
+
+      <div className="bg-slate-800/30 border border-slate-700/30 rounded-xl p-4">
+        <pre className="whitespace-pre-wrap text-slate-200 text-sm leading-relaxed font-mono">
+          {response}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+export default ClaudeResponseView;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@
 import path from "path";
 
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
@@ -14,5 +14,8 @@ export default defineConfig({
   build: {
     sourcemap: true,
     outDir: "dist",
+  },
+  test: {
+    environment: "jsdom",
   },
 });


### PR DESCRIPTION
## Summary
- split ClaudePanel into ClaudeActionList, ClaudePromptForm, and ClaudeResponseView with parent coordinator
- extract IconButton and IconBadge reusable components
- add unit tests for new components

## Testing
- `pnpm lint` *(fails: Cannot resolve @testing-library/react and vitest)*
- `pnpm test` *(fails: vitest: not found)*
- `pnpm typecheck` *(fails: Cannot find modules '@testing-library/react', 'vitest', and 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_6898f41f16148321aec3a77001de8491